### PR TITLE
Better validIP Method

### DIFF
--- a/lib/helpers.py
+++ b/lib/helpers.py
@@ -5,7 +5,7 @@ Reusable helpers that don't quite fit anywhere else.
 """
 
 import zlib, re, textwrap, commands, datetime, time
-import random, string, string, base64, os
+import random, string, base64, os, socket
 
 import settings
 
@@ -29,9 +29,10 @@ def validIP(IP):
     """
     Tries to validate an IP.
     """
-    if re.match(r'^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$', IP):
+    try:
+        socket.inet_aton(IP)
         return True
-    else:
+    except:
         return False
 
 

--- a/modules/template.py
+++ b/modules/template.py
@@ -48,7 +48,7 @@ class Module:
 
         for target in self.targets:
 
-            print " [*] Doing soemthing on %s" %(target)
+            print " [*] Doing something on %s" %(target)
             command = "something to do on the host"
 
             # ...


### PR DESCRIPTION
Updated the 'validIP' helper method to return True if the IP is actually
valid, unlike the regex version, which returned True even if the IP was
"999.999.999.999"
Also fixed a few spelling errors that I came across.

I apologize for the formatting, this is one of my first real "commits" and contributions on GitHub.
